### PR TITLE
Remove style for em

### DIFF
--- a/resources/screen.css
+++ b/resources/screen.css
@@ -278,10 +278,6 @@ a {
   text-decoration: none;
 }
 
-em {
-  font-style: italic;
-}
-
 p,
 li {
   margin: 1em 0;


### PR DESCRIPTION
Is it really needed? We are using `i` instead of `em` and I believe the `font-style` should be automatically set to `italic`.