### PR TITLE
Apply the "firstHeading" id instead of "mw-snapwikiskin-firstHeading" on first heading

### DIFF
--- a/resources/screen.css
+++ b/resources/screen.css
@@ -829,7 +829,7 @@ footer ul {
   list-style: none none;
 }
 
-#mw-snapwikiskin-firstHeading {
+#firstHeading {
   font-size: x-large;
   padding: 10px;
 }

--- a/templates/header.mustache
+++ b/templates/header.mustache
@@ -4,5 +4,5 @@
 			<div id="{{id}}" class="{{class}}">{{{html}}}</div>
 		{{/array-indicators}}
 	</div>
-	<h1 id="mw-snapwikiskin-firstHeading" {{{html-user-language-attributes}}}>{{{html-title}}}</h1>
+	<h1 id="firstHeading" {{{html-user-language-attributes}}}>{{{html-title}}}</h1>
 </header>


### PR DESCRIPTION
That is what Vector does, too and a lot of gadgets and stylesheets may be using it.