### PR TITLE
Remove Internet Explorer-specific Rules

### DIFF
--- a/resources/screen.css
+++ b/resources/screen.css
@@ -34,7 +34,6 @@ html {
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
   font-family: sans-serif;
-  -ms-text-size-adjust: 100%;
 }
 
 /*
@@ -512,7 +511,6 @@ h4 {
   white-space: nowrap;
   overflow-y: hidden;
   overflow-x: auto;
-  -ms-overflow-style: none;
   -webkit-overflow-scrolling: touch;
   padding: 0.5em 0;
 }


### PR DESCRIPTION
Microsoft will retire IE next year (see [corresponding blog post](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge/)). Many websites are dropping support for it and we should, too. 