### PR TITLE
Hide Thumbnail and Description & Show the Vue-based Search By Default

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -18,6 +18,9 @@
       "value": "",
       "description": "Override default search API. Can be used with $wgDisableTextSearch and $wgSearchForwardUrl to mimic user experience on production."
     },
+    "SnapwikiskinUseWvuiSearch": {
+      "value": true
+    },
     "SnapwikiskinWvuiSearchOptions": {
       "value": {
         "showThumbnail": false,
@@ -65,6 +68,7 @@
       ],
       "messages": ["searchbutton", "searchresults", "searchsuggest-containing"]
     },
+
     "skins.snapwikiskin": {
       "class": "ResourceLoaderSkinModule",
       "features": {

--- a/skin.json
+++ b/skin.json
@@ -19,12 +19,12 @@
       "description": "Override default search API. Can be used with $wgDisableTextSearch and $wgSearchForwardUrl to mimic user experience on production."
     },
     "SnapwikiskinUseWvuiSearch": {
-      "value": false
+      "value": true
     },
     "SnapwikiskinWvuiSearchOptions": {
       "value": {
-        "showThumbnail": true,
-        "showDescription": true
+        "showThumbnail": false,
+        "showDescription": false
       }
     }
   },

--- a/skin.json
+++ b/skin.json
@@ -18,9 +18,6 @@
       "value": "",
       "description": "Override default search API. Can be used with $wgDisableTextSearch and $wgSearchForwardUrl to mimic user experience on production."
     },
-    "SnapwikiskinUseWvuiSearch": {
-      "value": true
-    },
     "SnapwikiskinWvuiSearchOptions": {
       "value": {
         "showThumbnail": false,
@@ -68,7 +65,6 @@
       ],
       "messages": ["searchbutton", "searchresults", "searchsuggest-containing"]
     },
-
     "skins.snapwikiskin": {
       "class": "ResourceLoaderSkinModule",
       "features": {


### PR DESCRIPTION
The Vue-based search should always be used by default. And as for thumbnail and description, most wikis (including ours) do not have it.