### PR TITLE
Update to Vue 3

### DIFF
--- a/resources/screen.css
+++ b/resources/screen.css
@@ -101,7 +101,7 @@ code,
 kbd,
 samp,
 pre {
-  font-family: "ui-monospace", "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace; /* 1 */
+  font-family: ui-monospace, "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace; /* 1 */
   font-size: 1em; /* 2 */
 }
 
@@ -417,6 +417,7 @@ h4 {
   text-rendering: auto;
   width: 25%;
 }
+
 .inner {
   margin: 0 auto;
 }
@@ -426,26 +427,31 @@ h4 {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
 }
+
 .pure-menu-fixed {
   position: fixed;
   left: 0;
   top: 0;
   z-index: 3;
 }
+
 .pure-menu-list,
 .pure-menu-item {
   position: relative;
 }
+
 .pure-menu-list {
   list-style: none;
   margin: 0;
   padding: 0;
 }
+
 .pure-menu-item {
   padding: 0;
   margin: 0;
   height: 100%;
 }
+
 .pure-menu-link,
 .pure-menu-heading,
 .pure-menu-children > li {
@@ -454,13 +460,16 @@ h4 {
   white-space: nowrap;
   height: 100%;
 }
+
 .pure-menu-horizontal {
   width: 100%;
   white-space: nowrap;
 }
+
 .pure-menu-horizontal .pure-menu-list {
   display: inline-block;
 }
+
 .pure-menu-horizontal .pure-menu-item,
 .pure-menu-horizontal .pure-menu-heading,
 .pure-menu-horizontal .pure-menu-separator {
@@ -468,9 +477,11 @@ h4 {
   zoom: 1;
   vertical-align: middle;
 }
+
 .pure-menu-item .pure-menu-item {
   display: block;
 }
+
 .pure-menu-children {
   display: none;
   position: absolute;
@@ -481,34 +492,42 @@ h4 {
   z-index: 3;
   background-color: #fff;
 }
+
 .pure-menu-horizontal .pure-menu-children {
   left: 0;
   top: auto;
   width: inherit;
 }
+
 .pure-menu-allow-hover:hover > .pure-menu-children,
 .pure-menu-active > .pure-menu-children {
   display: block;
   position: absolute;
 }
+
 .pure-menu-has-children > .pure-menu-link:after {
   padding-left: 0.5em;
   content: "\25B8";
   font-size: small;
 }
+
 .pure-menu-horizontal .pure-menu-has-children > .pure-menu-link:after {
   content: "\25BE";
 }
+
 .pure-menu-scrollable {
   overflow-y: scroll;
   overflow-x: hidden;
 }
+
 .pure-menu-scrollable .pure-menu-list {
   display: block;
 }
+
 .pure-menu-horizontal.pure-menu-scrollable .pure-menu-list {
   display: inline-block;
 }
+
 .pure-menu-horizontal.pure-menu-scrollable {
   white-space: nowrap;
   overflow-y: hidden;
@@ -516,23 +535,28 @@ h4 {
   -webkit-overflow-scrolling: touch;
   padding: 0.5em 0;
 }
+
 .pure-menu-horizontal.pure-menu-scrollable::-webkit-scrollbar {
   display: none;
 }
+
 .pure-menu-separator {
   background-color: #ccc;
   height: 1px;
   margin: 0.3em 0;
 }
+
 .pure-menu-horizontal .pure-menu-separator {
   width: 1px;
   height: 1.3em;
   margin: 0 0.3em;
 }
+
 .pure-menu-heading {
   text-transform: uppercase;
   color: #565d64;
 }
+
 .pure-menu-link {
   color: #777;
 }
@@ -542,17 +566,21 @@ h4 {
 .pure-menu-heading {
   padding: 0.5em 1em;
 }
+
 .pure-menu-disabled {
   opacity: 0.5;
 }
+
 .pure-menu-disabled .pure-menu-link:hover {
   background-color: transparent;
 }
+
 .pure-menu-active > .pure-menu-link,
 .pure-menu-link:hover,
 .pure-menu-link:focus {
   background-color: #eee;
 }
+
 .pure-menu-selected .pure-menu-link,
 .pure-menu-selected .pure-menu-link:visited {
   color: #000;
@@ -611,103 +639,131 @@ h4 {
   vertical-align: top;
   text-rendering: auto;
 }
+
 .pure-u-1-24 {
   width: 4.1667%;
 }
+
 .pure-u-1-12,
 .pure-u-2-24 {
   width: 8.3333%;
   height: 10px;
 }
+
 .pure-u-1-8,
 .pure-u-3-24 {
   width: 12.5%;
 }
+
 .pure-u-1-6,
 .pure-u-4-24 {
   width: 16.6667%;
 }
+
 .pure-u-1-5 {
   width: 20%;
 }
+
 .pure-u-5-24 {
   width: 20.8333%;
 }
+
 .pure-u-1-4,
 .pure-u-6-24 {
   width: 25%;
 }
+
 .pure-u-7-24 {
   width: 29.1667%;
 }
+
 .pure-u-1-3,
 .pure-u-8-24 {
   width: 33.3333%;
 }
+
 .pure-u-3-8,
 .pure-u-9-24 {
   width: 37.5%;
 }
+
 .pure-u-2-5 {
   width: 40%;
 }
+
 .pure-u-5-12,
 .pure-u-10-24 {
   width: 41.6667%;
 }
+
 .pure-u-11-24 {
   width: 45.8333%;
 }
+
 .pure-u-1-2,
 .pure-u-12-24 {
   width: 50%;
 }
+
 .pure-u-13-24 {
   width: 54.1667%;
 }
+
 .pure-u-7-12,
 .pure-u-14-24 {
   width: 58.3333%;
 }
+
 .pure-u-3-5 {
   width: 60%;
 }
+
 .pure-u-5-8,
 .pure-u-15-24 {
   width: 62.5%;
 }
+
 .pure-u-2-3,
 .pure-u-16-24 {
   width: 66.6667%;
 }
+
 .pure-u-17-24 {
   width: 70.8333%;
 }
+
 .pure-u-3-4,
 .pure-u-18-24 {
   width: 75%;
 }
+
 .pure-u-19-24 {
   width: 79.1667%;
 }
+
 .pure-u-4-5 {
   width: 80%;
 }
+
 .pure-u-5-6,
 .pure-u-20-24 {
   width: 83.3333%;
 }
+
 .pure-u-7-8,
 .pure-u-21-24 {
   width: 87.5%;
 }
+
 .pure-u-11-12,
 .pure-u-22-24 {
   width: 91.6667%;
 }
+
 .pure-u-23-24 {
   width: 95.8333%;
 }
+
 .pure-u-1,
 .pure-u-1-1,
 .pure-u-5-5,
@@ -724,6 +780,7 @@ footer {
   flex-shrink: 0;
   font-size: 0.75em;
 }
+
 .links.pure-g {
   color: #fff;
   padding: 0;
@@ -732,7 +789,7 @@ footer {
   font-size: 100%;
   vertical-align: baseline;
   letter-spacing: -0.31em;
-  text-rendering: optimizeSpeed;
+  text-rendering: optimizespeed;
   font-family: "FreeSans", "Arimo", "Droid Sans", "Helvetica", "Arial", sans-serif;
   display: -webkit-flex;
   -webkit-flex-flow: row wrap;
@@ -769,19 +826,23 @@ footer ul {
   font-size: x-large;
   padding: 10px;
 }
+
 .mw-body .mw-indicators {
   font-size: 0.875em;
   line-height: 1.6;
   position: relative;
 }
+
 .mw-indicators {
   float: right;
   z-index: 1;
 }
+
 .mw-body-content {
   position: relative;
   z-index: 0;
 }
+
 .mw-snapwikiskin-main {
   margin-top: 50px;
   padding-left: 5px;
@@ -840,6 +901,7 @@ textarea {
 #mw-contentwrapper {
   flex: 1;
 }
+
 .mw-editsection {
   font-size: 0.8rem;
   font-family: system-ui, -apple-system, "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif, "Apple Color Emoji",

--- a/resources/skins.snapwikiskin.search/skins.snapwikiskin.search.js
+++ b/resources/skins.snapwikiskin.search/skins.snapwikiskin.search.js
@@ -8,17 +8,7 @@ const Vue = require("vue").default || require("vue"),
  * @return {void}
  */
 function initApp(searchForm, search) {
-  // eslint-disable-next-line no-new
-  new Vue({
-    el: searchForm,
-    /**
-     *
-     * @param {Function} createElement
-     * @return {Vue.VNode}
-     */
-    render: function (createElement) {
-      return createElement(App, {
-        props: $.extend(
+  Vue.createMwapp(App, $.extend(
           {
             autofocusInput: search === document.activeElement,
             action: searchForm.getAttribute("action"),
@@ -28,11 +18,7 @@ function initApp(searchForm, search) {
             searchQuery: search.value,
           },
           // Pass additional config from server.
-          config
-        ),
-      });
-    },
-  });
+          config)).mount(searchForm.parentNode);
 }
 /**
  * @param {Document} document

--- a/resources/skins.snapwikiskin.search/skins.snapwikiskin.search.js
+++ b/resources/skins.snapwikiskin.search/skins.snapwikiskin.search.js
@@ -8,7 +8,7 @@ const Vue = require("vue").default || require("vue"),
  * @return {void}
  */
 function initApp(searchForm, search) {
-  Vue.createMwapp(
+  Vue.createMwApp(
     App,
     $.extend(
       {

--- a/resources/skins.snapwikiskin.search/skins.snapwikiskin.search.js
+++ b/resources/skins.snapwikiskin.search/skins.snapwikiskin.search.js
@@ -8,17 +8,21 @@ const Vue = require("vue").default || require("vue"),
  * @return {void}
  */
 function initApp(searchForm, search) {
-  Vue.createMwapp(App, $.extend(
-          {
-            autofocusInput: search === document.activeElement,
-            action: searchForm.getAttribute("action"),
-            searchAccessKey: search.getAttribute("accessKey"),
-            searchTitle: search.getAttribute("title"),
-            searchPlaceholder: search.getAttribute("placeholder"),
-            searchQuery: search.value,
-          },
-          // Pass additional config from server.
-          config)).mount(searchForm.parentNode);
+  Vue.createMwapp(
+    App,
+    $.extend(
+      {
+        autofocusInput: search === document.activeElement,
+        action: searchForm.getAttribute("action"),
+        searchAccessKey: search.getAttribute("accessKey"),
+        searchTitle: search.getAttribute("title"),
+        searchPlaceholder: search.getAttribute("placeholder"),
+        searchQuery: search.value,
+      },
+      // Pass additional config from server.
+      config
+    )
+  ).mount(searchForm.parentNode);
 }
 /**
  * @param {Document} document

--- a/skin.json
+++ b/skin.json
@@ -5,10 +5,10 @@
   "descriptionmsg": "snapwikiskin-desc",
   "license-name": "GPL-3.0-or-later",
   "type": "skin",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "url": "https://www.mediawiki.org/wiki/Skin:Snap!_Wiki_Skin",
   "requires": {
-    "MediaWiki": ">= 1.37.0"
+    "MediaWiki": ">= 1.38.0"
   },
   "AutoloadNamespaces": {
     "Snapwikiskin\\": "includes/"


### PR DESCRIPTION
Resolves #75 by updating to Vue 3.

Changes:

- Replaces ``new Vue`` with ``Vue.createMwapp``, MediaWiki's wrapper over Vue's ``createApp``
- Explicitly tells Vue to mount on the ``parentNode`` because apparently it creates a new, potentially breaking element in Vue 3
- Raises MW version requirement to 1.38
- Bumps the version to 3.0.0 since this is a breaking change