### PR TITLE
Replace deprecated SkinModule features

### DIFF
--- a/.styelintignore
+++ b/.styelintignore
@@ -1,2 +1,2 @@
-vendor/**/*.css
-node_modules/**/*.css
+vendor/**
+node_modules/**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "prettier --check .",
     "fix": "prettier --write .",
-    "lint": "stylelint \"**/**.css\" --fix"
+    "lint": "stylelint \"**/**.less\" --fix"
   },
   "devDependencies": {
     "browserslist": "^4.28.1",

--- a/resources/screen.less
+++ b/resources/screen.less
@@ -1,3 +1,23 @@
+/* These styles for lists are here as replacement for the i18n-all-lists-margins feature formerly provided by MediaWiki core. */
+@import 'mediawiki.mixins.less';
+
+ul {
+	margin-top: 0.3em;
+	.margin-inline( 1.6em, 0 );
+	padding: 0.5em 0;
+}
+
+ol {
+	margin-top: 0.3em;
+	.margin-inline( 3.2em, 0 );
+	padding: 0.5em 0;
+  list-style: decimal inside;
+}
+
+dd {
+	.margin-inline( 1.6em, 0 );
+}
+
 /* Begin reset */
 
 /*! modern-normalize v1.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
@@ -291,15 +311,6 @@ li {
 
 p {
   line-height: 1.2em;
-}
-
-ul,
-ol {
-  padding: 0.5em 0;
-}
-
-ol {
-  list-style: decimal inside;
 }
 
 h2 {

--- a/resources/screen.less
+++ b/resources/screen.less
@@ -1,21 +1,21 @@
 /* These styles for lists are here as replacement for the i18n-all-lists-margins feature formerly provided by MediaWiki core. */
-@import 'mediawiki.mixins.less';
+@import "mediawiki.mixins.less";
 
 ul {
-	margin-top: 0.3em;
-	.margin-inline( 1.6em, 0 );
-	padding: 0.5em 0;
+  margin-top: 0.3em;
+  .margin-inline( 1.6em, 0 );
+  padding: 0.5em 0;
 }
 
 ol {
-	margin-top: 0.3em;
-	.margin-inline( 3.2em, 0 );
-	padding: 0.5em 0;
+  margin-top: 0.3em;
+  .margin-inline( 3.2em, 0 );
+  padding: 0.5em 0;
   list-style: decimal inside;
 }
 
 dd {
-	.margin-inline( 1.6em, 0 );
+  .margin-inline( 1.6em, 0 );
 }
 
 /* Begin reset */

--- a/skin.json
+++ b/skin.json
@@ -81,7 +81,7 @@
         "normalize": false
       },
       "styles": {
-        "resources/screen.css": {
+        "resources/screen.less": {
           "media": "screen"
         }
       }

--- a/skin.json
+++ b/skin.json
@@ -72,14 +72,12 @@
       "class": "MediaWiki\\ResourceLoader\\SkinModule",
       "features": {
         "content-media": true,
-        "content-parser-output": true,
+        "content-body": true,
         "content-tables": true,
         "content-links": true,
         "i18n-ordered-lists": true,
-        "i18n-all-lists-margins": true,
         "i18n-headings": true,
         "interface-category": true,
-        "interface-message-box": true,
         "normalize": false
       },
       "styles": {


### PR DESCRIPTION
- `content-parser-output` has been replaced with `content-body`.
- `i18n-all-lists-margins` has been removed from MW core without a light-weight replacement.
- `interface-message-box` does not have any replacement but we do not need it either anymore.