### PR TITLE
Make sure the search bar doesn’t overlap with the pencil icon

### DIFF
--- a/resources/screen.css
+++ b/resources/screen.css
@@ -942,3 +942,9 @@ textarea {
   font-weight: bold;
   color: #a55858;
 }
+
+#typehead-search{
+  position:absolute;
+  right:1px;
+  top:8.3px;
+}


### PR DESCRIPTION
Fixes the problem of the search bar overlapping with the pencil icon.